### PR TITLE
Allow including stop button in compact view

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }
@@ -16,6 +17,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         mavenCentral()
         google()
         maven { url "https://jitpack.io" }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/NotificationConfig.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/NotificationConfig.kt
@@ -22,6 +22,7 @@ data class NotificationConfig(
  * Provide customized notification buttons. They will be shown by default. Note that buttons can still be shown and hidden at runtime by using the functions in [NotificationManager][com.doublesymmetry.kotlinaudio.notification.NotificationManager], but they will have the default icon if not set explicitly here.
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showPlayPauseButton]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showStopButton]
+ * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showStopButtonCompact]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showBackwardButton]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showBackwardButtonCompact]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showForwardButton]
@@ -34,7 +35,7 @@ data class NotificationConfig(
 sealed class NotificationButton(@DrawableRes val icon: Int?) {
     class PLAY(@DrawableRes icon: Int? = null): NotificationButton(icon)
     class PAUSE(@DrawableRes icon: Int? = null): NotificationButton(icon)
-    class STOP(@DrawableRes icon: Int? = null): NotificationButton(icon)
+    class STOP(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)
     class FORWARD(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)
     class BACKWARD(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)
     class NEXT(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -75,6 +75,12 @@ class NotificationManager internal constructor(private val context: Context, pri
             internalManager?.useStopAction = value
         }
 
+    var showStopButtonCompact: Boolean
+        get() = internalManager?.useStopActionInCompactView ?: false
+        set(value) {
+            internalManager?.useStopActionInCompactView = value
+        }
+
     var showForwardButton: Boolean
         get() = internalManager?.useFastForwardAction ?: false
         set(value) {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -215,7 +215,10 @@ class NotificationManager internal constructor(private val context: Context, pri
                 config.buttons.forEach { button ->
                     when (button) {
                         is NotificationButton.PLAY, is NotificationButton.PAUSE -> showPlayPauseButton = true
-                        is NotificationButton.STOP -> showStopButton = true
+                        is NotificationButton.STOP -> {
+                            showStopButton = true
+                            showStopButtonCompact = button.isCompact
+                        }
                         is NotificationButton.FORWARD -> {
                             showForwardButton = true
                             showForwardButtonCompact = button.isCompact


### PR DESCRIPTION
This pull request fixes the following issue where the stop button was no longer showing up in the compact notification: https://github.com/DoubleSymmetry/react-native-track-player/issues/1382

Since kotlin does not seem to allow overriding  protected methods, I had to override `getActionIndicesForCompactView` using a java class. Perhaps there is another way?