### PR TITLE
Provide MediaSession with metadata to support AOD

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.os.ResultReceiver
+import android.support.v4.media.MediaMetadataCompat.*
 import android.support.v4.media.RatingCompat
 import android.support.v4.media.session.MediaSessionCompat
 import com.doublesymmetry.kotlinaudio.R
@@ -216,6 +217,16 @@ class NotificationManager internal constructor(private val context: Context, pri
             }
         }.build()
 
+        mediaSessionConnector.setMediaMetadataProvider {
+            Builder().apply {
+                val title = descriptionAdapter.getCurrentContentTitle(it)
+                putText(METADATA_KEY_TITLE, title)
+
+                val artist = descriptionAdapter.getCurrentContentText(it)
+                if (artist != null) putText(METADATA_KEY_ARTIST, artist)
+            }.build()
+        }
+
         if (!isJUnitTest()) {
             internalManager?.apply {
                 setColor(config.accentColor ?: Color.TRANSPARENT)
@@ -298,6 +309,7 @@ class NotificationManager internal constructor(private val context: Context, pri
 
     private fun reload() = scope.launch {
         internalManager?.invalidate()
+        mediaSessionConnector.invalidateMediaSessionMetadata()
     }
 
     companion object {


### PR DESCRIPTION
This change should fix the "No title" in the lock screen/always-on-display issue that's cropped up in the Android rewrite for react-native-track-player.  Discussion about this issue can be found here: https://github.com/doublesymmetry/react-native-track-player/issues/1478

After doing some digging I found this issue in ExoPlayer https://github.com/google/ExoPlayer/issues/6624 which describes a similar issue, and the need to invalidate the metadata on changes, so I've taken an approach here that I think should provide metadata to the media session and also invalidate it when it changes.

I've tested this change in the RNTP example app (had to fix the one line with a typo in the word "notification" in order to use the latest KotlinAudio since it's still on 0.1.31) and it appears to work fine on the AOD now, displaying the title/artist as long as the song is playing.

I'm extremely new to Kotlin/working with Android at this level so please let me know if there's a better way to do any of this, I appreciate the feedback!