### PR TITLE
App process not dying properly

### DIFF
--- a/kotlin-audio/build.gradle
+++ b/kotlin-audio/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
 }
 
-def versionNumber = '0.1.33'
+def versionNumber = '0.1.35'
 
 group = 'com.github.doublesymmetry'
 version = versionNumber

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -35,7 +35,10 @@ class NotificationManager internal constructor(private val context: Context, pri
     var notificationMetadata: NotificationMetadata? = null
         set(value) {
             field = value
-            reload()
+
+            scope.launch {
+                reload()
+            }
         }
 
     var ratingType: Int = RatingCompat.RATING_NONE
@@ -254,7 +257,7 @@ class NotificationManager internal constructor(private val context: Context, pri
     }
 
     // FIXME: This functions seems wrong. It does not do what the name suggests...
-    fun clearNotification() = scope.launch {
+    fun clearNotification() {
         mediaSession.isActive = false
         internalManager?.setPlayer(null)
     }
@@ -268,12 +271,16 @@ class NotificationManager internal constructor(private val context: Context, pri
     override fun onNotificationPosted(notificationId: Int, notification: Notification, ongoing: Boolean) {
         scope.launch {
             event.updateNotificationState(NotificationState.POSTED(notificationId, notification, ongoing))
+
+            reload()
         }
     }
 
     override fun onNotificationCancelled(notificationId: Int, dismissedByUser: Boolean) {
         scope.launch {
             event.updateNotificationState(NotificationState.CANCELLED(notificationId))
+
+            reload()
         }
     }
 
@@ -291,9 +298,9 @@ class NotificationManager internal constructor(private val context: Context, pri
     }
 
     internal fun destroy() = scope.launch {
+        internalManager?.setPlayer(null)
         mediaSession.isActive = false
         descriptionAdapter.release()
-        internalManager?.setPlayer(null)
     }
 
     private fun reload() = scope.launch {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -185,9 +185,9 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
     open fun destroy() {
         abandonAudioFocusIfHeld()
         stop()
-        notificationManager.destroy()
         exoPlayer.release()
         cache?.release()
+        notificationManager.destroy()
     }
 
     fun seek(duration: Long, unit: TimeUnit) {


### PR DESCRIPTION
Trying to fix the process not stopping bug introduced another bug, where our foreground notification would disappear when we put the app to recents. This only happens the first time.

I still don't know the cause of it, but it's not something that should happen or is intended in Android. ESPECIALLY for a media style foreground notification. 

The potential "brute force" fix was to `reload` the notification on every event, so that it would appear when it disappears.
This however caused the notification to flicker when it disappears and appears again, as well as causing the notification to stay showing even when we completely kill the app + process.

My other theory is that we should not be using `reload` at all, since it completely re-renders the notification and causes it to misbehave. 
Before this PR, we were already using `reload` in `onPlay` and `onPause`. The `reload` function was added to fix [this](https://github.com/doublesymmetry/KotlinAudio/pull/16) bug, but I am not sure if that was the correct way to fix this.