### PR TITLE
Provide notification all buttons regardless of queue state

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/InternalNotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/InternalNotificationManager.kt
@@ -1,0 +1,105 @@
+package com.doublesymmetry.kotlinaudio.notification
+
+import android.content.Context
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.ui.PlayerNotificationManager
+import com.google.android.exoplayer2.util.NotificationUtil
+
+class InternalNotificationManager(
+    context: Context,
+    channelId: String,
+    notificationId: Int,
+    mediaDescriptionAdapter: MediaDescriptionAdapter,
+    notificationListener: NotificationListener?,
+    primaryActionReceiver: PrimaryActionReceiver?,
+    customActionReceiver: CustomActionReceiver?,
+    smallIconResourceId: Int,
+    playActionIconResourceId: Int,
+    pauseActionIconResourceId: Int,
+    stopActionIconResourceId: Int,
+    rewindActionIconResourceId: Int,
+    fastForwardActionIconResourceId: Int,
+    previousActionIconResourceId: Int,
+    nextActionIconResourceId: Int,
+    groupKey: String?
+) : PlayerNotificationManager(
+    context,
+    channelId,
+    notificationId,
+    mediaDescriptionAdapter,
+    notificationListener,
+    primaryActionReceiver,
+    customActionReceiver,
+    smallIconResourceId,
+    playActionIconResourceId,
+    pauseActionIconResourceId,
+    stopActionIconResourceId,
+    rewindActionIconResourceId,
+    fastForwardActionIconResourceId,
+    previousActionIconResourceId,
+    nextActionIconResourceId,
+    groupKey
+) {
+    override fun getActions(player: Player): MutableList<String> {
+        val stringActions: MutableList<String> = ArrayList()
+        if (usePreviousAction) {
+            stringActions.add(ACTION_PREVIOUS)
+        }
+        if (useRewindAction) {
+            stringActions.add(ACTION_REWIND)
+        }
+        if (usePlayPauseActions) {
+            if (shouldShowPauseButton(player)) {
+                stringActions.add(ACTION_PAUSE)
+            } else {
+                stringActions.add(ACTION_PLAY)
+            }
+        }
+        if (useStopAction) {
+            stringActions.add(ACTION_STOP)
+        }
+        if (useFastForwardAction) {
+            stringActions.add(ACTION_FAST_FORWARD)
+        }
+        if (useNextAction) {
+            stringActions.add(ACTION_NEXT)
+        }
+        return stringActions
+    }
+
+    private fun shouldShowPauseButton(player: Player): Boolean {
+        return player.playbackState != Player.STATE_ENDED && player.playbackState != Player.STATE_IDLE && player.playWhenReady
+    }
+
+    class Builder(context: Context, notificationId: Int, channelId: String): PlayerNotificationManager.Builder(context, notificationId, channelId) {
+        override fun build(): InternalNotificationManager {
+            if (channelNameResourceId != 0) {
+                NotificationUtil.createNotificationChannel(
+                    context,
+                    channelId,
+                    channelNameResourceId,
+                    channelDescriptionResourceId,
+                    channelImportance
+                )
+            }
+            return InternalNotificationManager(
+                context,
+                channelId,
+                notificationId,
+                mediaDescriptionAdapter,
+                notificationListener,
+                primaryActionReceiver,
+                customActionReceiver,
+                smallIconResourceId,
+                playActionIconResourceId,
+                pauseActionIconResourceId,
+                stopActionIconResourceId,
+                rewindActionIconResourceId,
+                fastForwardActionIconResourceId,
+                previousActionIconResourceId,
+                nextActionIconResourceId,
+                groupKey
+            )
+        }
+    }
+}

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 class NotificationManager internal constructor(private val context: Context, private val exoPlayer: ExoPlayer, private val event: NotificationEventHolder) :
     PlayerNotificationManager.PrimaryActionReceiver, PlayerNotificationManager.NotificationListener {
     private lateinit var descriptionAdapter: DescriptionAdapter
-    private var internalManager: PlayerNotificationManager? = null
+    private var internalManager: InternalNotificationManager? = null
 
     private val mediaSession: MediaSessionCompat = MediaSessionCompat(context, "AudioPlayerSession")
     private val mediaSessionConnector: MediaSessionConnector = MediaSessionConnector(mediaSession)
@@ -195,7 +195,7 @@ class NotificationManager internal constructor(private val context: Context, pri
             }
         }, context, config.pendingIntent)
 
-        internalManager = PlayerNotificationManager.Builder(context, NOTIFICATION_ID, CHANNEL_ID).apply {
+        internalManager = InternalNotificationManager.Builder(context, NOTIFICATION_ID, CHANNEL_ID).apply {
             setChannelNameResourceId(R.string.playback_channel_name)
             setMediaDescriptionAdapter(descriptionAdapter)
             setNotificationListener(this@NotificationManager)


### PR DESCRIPTION
Extends the `PlayerNotificationManager` so that we can override `getActions()` and return the same notification buttons as in RNTP `v2.1.3`.  Primary change here is to keep all buttons in the notification regardless of queue state so that they don't disappear/shift around in the UI.  Secondarily I have also changed the order back to what it was previously, where stop is after play/pause instead of after forward.

The reason I'm opening this as a draft however is that I think this probably makes more sense to change directly inside of ExoPlayer, since you're already forking it and even making changes in this file, but I can't for the life of me figure out how to include my local build of ExoPlayer in the RNTP example app for testing.  @mpivchev or @dcvz could you provide some guidance on this?  Tips for including KotlinAudio locally would also be appreciated as right now my strategy is just to build the AAR and include it and all of KotlinAudio's dependencies directly in RNTP (which works but doesn't seem like the best way, and I can't seem to get this strategy to work with ExoPlayer being another AAR level deep):

```groovy
dependencies {
//    implementation 'com.github.DoubleSymmetry:KotlinAudio:v0.1.31'
    def kotlinAudioPath = "/home/austin/repos/KotlinAudio/kotlin-audio/build/outputs/aar/"
    debugImplementation files(kotlinAudioPath + "kotlin-audio-debug.aar")
    releaseImplementation files(kotlinAudioPath + "kotlin-audio-release.aar")

    testImplementation 'junit:junit:4.13.2'
    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
    implementation 'io.coil-kt:coil:1.4.0'
    implementation 'androidx.media:media:1.4.3'
    api 'com.github.DoubleSymmetry.ExoPlayer:exoplayer:r2.16.4'
    api 'com.github.DoubleSymmetry.ExoPlayer:extension-mediasession:r2.16.4'
    api 'com.jakewharton.timber:timber:5.0.1'
...
}
```

RNTP issue: https://github.com/doublesymmetry/react-native-track-player/issues/1490