### PR TITLE
fix(queuedaudioplayer): fix an issue causing playback to pause if pla…

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -74,12 +74,16 @@ class QueuedAudioPlayer(context: Context, bufferConfig: BufferConfig? = null, ca
      * @param playWhenReady If this is `true` it will automatically start playback. Default is `true`.
      */
     fun add(item: AudioItem, playWhenReady: Boolean = true) {
+        val hasCurrentItem = currentItem != null
         val mediaSource = getMediaSourceFromAudioItem(item)
         queue.add(mediaSource)
         exoPlayer.addMediaSource(mediaSource)
 
         exoPlayer.prepare()
-        exoPlayer.playWhenReady = playWhenReady
+
+        if (!hasCurrentItem && playWhenReady) {
+            exoPlayer.playWhenReady = playWhenReady
+        }
     }
 
     /**
@@ -88,12 +92,16 @@ class QueuedAudioPlayer(context: Context, bufferConfig: BufferConfig? = null, ca
      * @param playWhenReady If this is `true` it will automatically start playback. Default is `true`.
      */
     fun add(items: List<AudioItem>, playWhenReady: Boolean = true) {
+        val hasCurrentItem = currentItem != null
         val mediaSources = items.map { getMediaSourceFromAudioItem(it) }
         queue.addAll(mediaSources)
         exoPlayer.addMediaSources(mediaSources)
 
         exoPlayer.prepare()
-        exoPlayer.playWhenReady = playWhenReady
+
+        if (!hasCurrentItem && playWhenReady) {
+            exoPlayer.playWhenReady = playWhenReady
+        }
     }
 
     /**


### PR DESCRIPTION
…yWhenReady is false

if a track is already playing and another track is added with playWhenReady is passed as false the
currently playing item will pause

https://github.com/doublesymmetry/react-native-track-player/issues/1513