### PR TITLE
feat(baseaudioplayer): add a position to the AudioItemTransition event

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioItemTransitionReason.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioItemTransitionReason.kt
@@ -1,29 +1,29 @@
 package com.doublesymmetry.kotlinaudio.models
 
-enum class AudioItemTransitionReason {
+sealed class AudioItemTransitionReason(val position: Long) {
     /**
      * Playback has automatically transitioned to the next [AudioItem].
      *
      * This reason also indicates a transition caused by another player.
      */
-    AUTO,
+    class AUTO(position: Long) : AudioItemTransitionReason(position)
 
     /**
      * A seek to another [AudioItem] has occurred. Usually triggered when calling
      * [QueuedAudioPlayer.next][com.doublesymmetry.kotlinaudio.players.QueuedAudioPlayer.next]
      * or [QueuedAudioPlayer.previous][com.doublesymmetry.kotlinaudio.players.QueuedAudioPlayer.previous].
      */
-    SEEK_TO_ANOTHER_AUDIO_ITEM,
+    class SEEK_TO_ANOTHER_AUDIO_ITEM(position: Long) : AudioItemTransitionReason(position)
 
     /**
      * The [AudioItem] has been repeated.
      */
-    REPEAT,
+    class REPEAT(position: Long) : AudioItemTransitionReason(position)
 
     /**
      * The current [AudioItem] has changed because of a change in the queue. This can either be if
      * the [AudioItem] previously being played has been removed, or when the queue becomes non-empty
      * after being empty.
      */
-    QUEUE_CHANGED
+    class QUEUE_CHANGED(position: Long) : AudioItemTransitionReason(position)
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.media.AudioManager
 import android.media.AudioManager.AUDIOFOCUS_LOSS
 import android.net.Uri
+import android.util.Log
 import androidx.annotation.CallSuper
 import androidx.core.content.ContextCompat
 import androidx.media.AudioAttributesCompat
@@ -367,11 +368,20 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         }
 
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            // NOTE: that position is pretty much always `0` here. My theory is that this
+            // method is called _after_ the player has already transitioned to the next item
+            // meaning that `.position` is the position of the next item, not the last one
+            // which is what we care about.
+            Log.d("RNTP", ">>>>>>> onMediaTransition: " + position)
             when (reason) {
-                Player.MEDIA_ITEM_TRANSITION_REASON_AUTO -> playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.AUTO)
-                Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED -> playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.QUEUE_CHANGED)
-                Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT -> playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.REPEAT)
-                Player.MEDIA_ITEM_TRANSITION_REASON_SEEK -> playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.SEEK_TO_ANOTHER_AUDIO_ITEM)
+                Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ->
+                    playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.AUTO(position))
+                Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED ->
+                    playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.QUEUE_CHANGED(position))
+                Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT ->
+                    playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.REPEAT(position))
+                Player.MEDIA_ITEM_TRANSITION_REASON_SEEK ->
+                    playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.SEEK_TO_ANOTHER_AUDIO_ITEM(position))
             }
 
             if (automaticallyUpdateNotificationMetadata)


### PR DESCRIPTION
https://github.com/doublesymmetry/react-native-track-player/issues/1613