### PR TITLE
Remove ExoPlayer fork dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.30"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/kotlin-audio-sample/src/androidTest/java/com/doublesymmetry/kotlin_audio_sample/QueuedAudioPlayerTest.kt
+++ b/kotlin-audio-sample/src/androidTest/java/com/doublesymmetry/kotlin_audio_sample/QueuedAudioPlayerTest.kt
@@ -6,11 +6,9 @@ import com.doublesymmetry.kotlin_audio_sample.utils.firstItem
 import com.doublesymmetry.kotlin_audio_sample.utils.secondItem
 import com.doublesymmetry.kotlinaudio.models.CacheConfig
 import com.doublesymmetry.kotlinaudio.players.QueuedAudioPlayer
-
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 @RunWith(AndroidJUnit4::class)
 class QueuedAudioPlayerTest {

--- a/kotlin-audio-sample/src/androidTest/java/com/doublesymmetry/kotlin_audio_sample/QueuedAudioPlayerTest.kt
+++ b/kotlin-audio-sample/src/androidTest/java/com/doublesymmetry/kotlin_audio_sample/QueuedAudioPlayerTest.kt
@@ -134,7 +134,7 @@ class QueuedAudioPlayerTest {
         val audioPlayer = QueuedAudioPlayer(appContext)
 
         audioPlayer.add(listOf(firstItem, secondItem), playWhenReady = false)
-        audioPlayer.stop()
+        audioPlayer.clearQueue()
         assertEquals(audioPlayer.nextItems.size, 0)
     }
     //endregion
@@ -183,7 +183,7 @@ class QueuedAudioPlayerTest {
         val audioPlayer = QueuedAudioPlayer(appContext)
 
         audioPlayer.add(listOf(firstItem, secondItem), playWhenReady = false)
-        audioPlayer.stop()
+        audioPlayer.clearQueue()
         assertEquals(audioPlayer.previousItems.size, 0)
     }
     //endregion

--- a/kotlin-audio-sample/src/main/java/com/doublesymmetry/kotlin_audio_sample/FirstFragment.kt
+++ b/kotlin-audio-sample/src/main/java/com/doublesymmetry/kotlin_audio_sample/FirstFragment.kt
@@ -105,18 +105,6 @@ class FirstFragment : Fragment() {
                         binding.textviewQueue.text = "${player.currentIndex + 1} / ${player.items.size}"
                     }
                 }
-
-                launch {
-                        player.event.onNotificationButtonTapped.collect {
-                            when (it) {
-                                is NotificationButton.PLAY -> player.play()
-                                is NotificationButton.PAUSE -> player.pause()
-                                is NotificationButton.NEXT -> player.next()
-                                is NotificationButton.PREVIOUS -> player.previous()
-                                else -> throw Error("This button has no function attached to it")
-                            }
-                        }
-                    }
             }
         }
     }

--- a/kotlin-audio/build.gradle
+++ b/kotlin-audio/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
 }
 
-def versionNumber = '1.0'
+def versionNumber = '1.1.0'
 
 group = 'com.github.doublesymmetry'
 version = versionNumber

--- a/kotlin-audio/build.gradle
+++ b/kotlin-audio/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
 }
 
-def versionNumber = '0.1.34'
+def versionNumber = '1.0'
 
 group = 'com.github.doublesymmetry'
 version = versionNumber
@@ -40,8 +40,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'io.coil-kt:coil:1.4.0'
     implementation 'androidx.media:media:1.6.0'
-    api 'com.github.doublesymmetry.Exoplayer:exoplayer:r2.17.2'
-    api 'com.github.doublesymmetry.Exoplayer:extension-mediasession:r2.17.2'
+    api 'com.google.android.exoplayer:exoplayer:2.18.1'
+    api 'com.google.android.exoplayer:extension-mediasession:2.18.1'
     api 'com.jakewharton.timber:timber:5.0.1'
 }
 

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/EventHolder.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/EventHolder.kt
@@ -19,10 +19,6 @@ class EventHolder internal constructor(private val notificationEventHolder: Noti
     val onMediaSessionCallbackTriggered
         get() = playerEventHolder.onMediaSessionCallbackTriggered
 
-    val onNotificationButtonTapped
-        get() = notificationEventHolder.onNotificationButtonTapped
-
     val notificationStateChange
         get() = notificationEventHolder.notificationStateChange
-
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/EventHolder.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/EventHolder.kt
@@ -16,12 +16,13 @@ class EventHolder internal constructor(private val notificationEventHolder: Noti
     val onPlaybackMetadata
         get() = playerEventHolder.onPlaybackMetadata
 
+    val onMediaSessionCallbackTriggered
+        get() = playerEventHolder.onMediaSessionCallbackTriggered
+
     val onNotificationButtonTapped
         get() = notificationEventHolder.onNotificationButtonTapped
 
     val notificationStateChange
         get() = notificationEventHolder.notificationStateChange
 
-    val onMediaSessionCallbackTriggered
-        get() = notificationEventHolder.onMediaSessionCallbackTriggered
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/NotificationEventHolder.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/NotificationEventHolder.kt
@@ -1,6 +1,5 @@
 package com.doublesymmetry.kotlinaudio.event
 
-import com.doublesymmetry.kotlinaudio.models.MediaSessionCallback
 import com.doublesymmetry.kotlinaudio.models.NotificationButton
 import com.doublesymmetry.kotlinaudio.models.NotificationState
 import kotlinx.coroutines.CoroutineScope
@@ -18,9 +17,6 @@ class NotificationEventHolder {
     private var _notificationStateChange = MutableSharedFlow<NotificationState>(1)
     var notificationStateChange = _notificationStateChange.asSharedFlow()
 
-    private var _onMediaSessionCallbackTriggered = MutableSharedFlow<MediaSessionCallback>()
-    var onMediaSessionCallbackTriggered = _onMediaSessionCallbackTriggered.asSharedFlow()
-
     internal fun updateOnNotificationButtonTapped(button: NotificationButton) {
         coroutineScope.launch {
             _onNotificationButtonTapped.emit(button)
@@ -30,12 +26,6 @@ class NotificationEventHolder {
     internal fun updateNotificationState(state: NotificationState) {
         coroutineScope.launch {
             _notificationStateChange.emit(state)
-        }
-    }
-
-    internal fun updateOnMediaSessionCallbackTriggered(callback: MediaSessionCallback) {
-        coroutineScope.launch {
-            _onMediaSessionCallbackTriggered.emit(callback)
         }
     }
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/NotificationEventHolder.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/NotificationEventHolder.kt
@@ -1,6 +1,5 @@
 package com.doublesymmetry.kotlinaudio.event
 
-import com.doublesymmetry.kotlinaudio.models.NotificationButton
 import com.doublesymmetry.kotlinaudio.models.NotificationState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,17 +10,8 @@ import kotlinx.coroutines.launch
 class NotificationEventHolder {
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
-    private var _onNotificationButtonTapped = MutableSharedFlow<NotificationButton>()
-    var onNotificationButtonTapped = _onNotificationButtonTapped.asSharedFlow()
-
     private var _notificationStateChange = MutableSharedFlow<NotificationState>(1)
     var notificationStateChange = _notificationStateChange.asSharedFlow()
-
-    internal fun updateOnNotificationButtonTapped(button: NotificationButton) {
-        coroutineScope.launch {
-            _onNotificationButtonTapped.emit(button)
-        }
-    }
 
     internal fun updateNotificationState(state: NotificationState) {
         coroutineScope.launch {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/PlayerEventHolder.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/event/PlayerEventHolder.kt
@@ -36,6 +36,9 @@ class PlayerEventHolder {
     private var _onPlaybackMetadata = MutableSharedFlow<PlaybackMetadata>(1)
     var onPlaybackMetadata = _onPlaybackMetadata.asSharedFlow()
 
+    private var _onMediaSessionCallbackTriggered = MutableSharedFlow<MediaSessionCallback>()
+    var onMediaSessionCallbackTriggered = _onMediaSessionCallbackTriggered.asSharedFlow()
+
     internal fun updateAudioPlayerState(state: AudioPlayerState) {
         coroutineScope.launch {
             _stateChange.emit(state)
@@ -69,6 +72,12 @@ class PlayerEventHolder {
     internal fun updateOnPlaybackMetadata(metadata: PlaybackMetadata) {
         coroutineScope.launch {
             _onPlaybackMetadata.emit(metadata)
+        }
+    }
+
+    internal fun updateOnMediaSessionCallbackTriggered(callback: MediaSessionCallback) {
+        coroutineScope.launch {
+            _onMediaSessionCallbackTriggered.emit(callback)
         }
     }
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioItem.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioItem.kt
@@ -1,7 +1,5 @@
 package com.doublesymmetry.kotlinaudio.models
 
-import android.support.v4.media.MediaMetadataCompat
-
 interface AudioItem {
     var audioUrl: String
     val type: MediaType
@@ -10,13 +8,6 @@ interface AudioItem {
     var albumTitle: String?
     val artwork: String?
     val options: AudioItemOptions?
-
-    val mediaMetadataCompat: MediaMetadataCompat
-        get() = MediaMetadataCompat.Builder()
-            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
-            .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
-            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, albumTitle)
-            .build()
 }
 
 data class AudioItemOptions(

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioItem.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioItem.kt
@@ -1,5 +1,7 @@
 package com.doublesymmetry.kotlinaudio.models
 
+import android.support.v4.media.MediaMetadataCompat
+
 interface AudioItem {
     var audioUrl: String
     val type: MediaType
@@ -8,6 +10,13 @@ interface AudioItem {
     var albumTitle: String?
     val artwork: String?
     val options: AudioItemOptions?
+
+    val mediaMetadataCompat: MediaMetadataCompat
+        get() = MediaMetadataCompat.Builder()
+            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
+            .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
+            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, albumTitle)
+            .build()
 }
 
 data class AudioItemOptions(

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/MediaSessionCallback.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/MediaSessionCallback.kt
@@ -3,8 +3,14 @@ package com.doublesymmetry.kotlinaudio.models
 import android.os.Bundle
 import android.support.v4.media.RatingCompat
 
-
 sealed class MediaSessionCallback {
-    class RATING(val rating: RatingCompat, val extras: Bundle?): MediaSessionCallback()
-    class SEEK(val position: Long, val extras: Bundle?): MediaSessionCallback()
+    class RATING(val rating: RatingCompat, extras: Bundle?): MediaSessionCallback()
+    object PLAY : MediaSessionCallback()
+    object PAUSE : MediaSessionCallback()
+    object NEXT : MediaSessionCallback()
+    object PREVIOUS : MediaSessionCallback()
+    object FORWARD : MediaSessionCallback()
+    object REWIND : MediaSessionCallback()
+    object STOP : MediaSessionCallback()
+    class SEEK(val position: Long): MediaSessionCallback()
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/NotificationConfig.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/NotificationConfig.kt
@@ -22,9 +22,8 @@ data class NotificationConfig(
  * Provide customized notification buttons. They will be shown by default. Note that buttons can still be shown and hidden at runtime by using the functions in [NotificationManager][com.doublesymmetry.kotlinaudio.notification.NotificationManager], but they will have the default icon if not set explicitly here.
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showPlayPauseButton]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showStopButton]
- * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showStopButtonCompact]
- * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showBackwardButton]
- * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showBackwardButtonCompact]
+ * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showRewindButton]
+ * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showRewindButtonCompact]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showForwardButton]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showForwardButtonCompact]
  * @see [com.doublesymmetry.kotlinaudio.notification.NotificationManager.showNextButton]
@@ -35,7 +34,7 @@ data class NotificationConfig(
 sealed class NotificationButton(@DrawableRes val icon: Int?) {
     class PLAY(@DrawableRes icon: Int? = null): NotificationButton(icon)
     class PAUSE(@DrawableRes icon: Int? = null): NotificationButton(icon)
-    class STOP(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)
+    class STOP(@DrawableRes icon: Int? = null): NotificationButton(icon)
     class FORWARD(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)
     class BACKWARD(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)
     class NEXT(@DrawableRes icon: Int? = null, val isCompact: Boolean = false): NotificationButton(icon)

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -20,12 +20,7 @@ import kotlinx.coroutines.launch
 class NotificationManager internal constructor(private val context: Context, private val exoPlayer: ExoPlayer, private val mediaSessionToken: MediaSessionCompat.Token, private val event: NotificationEventHolder) : PlayerNotificationManager.NotificationListener {
     private lateinit var descriptionAdapter: DescriptionAdapter
     private var internalNotificationManager: PlayerNotificationManager? = null
-
-//    private val mediaSession = MediaSessionCompat(context, "AudioPlayerSession")
-//    private val mediaSessionConnector = MediaSessionConnector(mediaSession)
-
     private val scope = CoroutineScope(Dispatchers.Main)
-
     private val buttons = mutableSetOf<NotificationButton?>()
 
     var notificationMetadata: NotificationMetadata? = null
@@ -33,29 +28,6 @@ class NotificationManager internal constructor(private val context: Context, pri
             field = value
             reload()
         }
-
-//    var ratingType: Int = RatingCompat.RATING_NONE
-//        set(value) {
-//            field = value
-//
-//            scope.launch {
-//                mediaSession.setRatingType(ratingType)
-//                mediaSessionConnector.setRatingCallback(object : MediaSessionConnector.RatingCallback {
-//                    override fun onCommand(player: Player, command: String, extras: Bundle?, cb: ResultReceiver?): Boolean {
-//                        return true
-//                    }
-//
-//                    override fun onSetRating(player: Player, rating: RatingCompat) {
-//                        event.updateOnMediaSessionCallbackTriggered(MediaSessionCallback.RATING(rating, null))
-//                    }
-//
-//                    override fun onSetRating(player: Player, rating: RatingCompat, extras: Bundle?) {
-//                        event.updateOnMediaSessionCallbackTriggered(MediaSessionCallback.RATING(rating, extras))
-//                    }
-//
-//                })
-//            }
-//        }
 
     var showPlayPauseButton = true
         set(value) {
@@ -149,24 +121,6 @@ class NotificationManager internal constructor(private val context: Context, pri
             }
         }
 
-//    init {
-//        mediaSession.setCallback(object : MediaSessionCompat.Callback() {
-//            override fun onSkipToNext() {
-//                super.onSkipToNext()
-//            }
-//            override fun onSeekTo(pos: Long) {
-//                super.onSeekTo(pos)
-//                event.updateOnMediaSessionCallbackTriggered(MediaSessionCallback.SEEK(position = pos, null))
-//            }
-//        })
-//
-//        scope.launch {
-//            if (!isJUnitTest()) {
-//                mediaSessionConnector.setPlayer(exoPlayer)
-//            }
-//        }
-//    }
-
     /**
      * Create a media player notification that automatically updates.
      *
@@ -198,8 +152,6 @@ class NotificationManager internal constructor(private val context: Context, pri
             setNotificationListener(this@NotificationManager)
 
             if (buttons.isNotEmpty()) {
-//                setPrimaryActionReceiver(this@NotificationManager)
-
                 config.buttons.forEach { button ->
                     when (button) {
                         is NotificationButton.PLAY -> button.icon?.let { setPlayActionIconResourceId(it) }
@@ -256,12 +208,6 @@ class NotificationManager internal constructor(private val context: Context, pri
         internalNotificationManager?.setPlayer(null)
     }
 
-//    override fun onAction(player: Player, action: String, intent: Intent) {
-//        scope.launch {
-//            event.updateOnNotificationButtonTapped(NotificationButton.valueOf(action))
-//        }
-//    }
-
     override fun onNotificationPosted(notificationId: Int, notification: Notification, ongoing: Boolean) {
         scope.launch {
             event.updateNotificationState(NotificationState.POSTED(notificationId, notification, ongoing))
@@ -274,21 +220,7 @@ class NotificationManager internal constructor(private val context: Context, pri
         }
     }
 
-//    internal fun onPlay() = scope.launch {
-//        mediaSession.isActive = true
-//        reload()
-//    }
-//
-//    internal fun onPause() = scope.launch {
-//        reload()
-//    }
-//
-//    fun onUnbind() = scope.launch {
-//        reload()
-//    }
-
     internal fun destroy() = scope.launch {
-//        mediaSession.isActive = false
         descriptionAdapter.release()
         internalNotificationManager?.setPlayer(null)
     }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -2,7 +2,6 @@ package com.doublesymmetry.kotlinaudio.notification
 
 import android.app.Notification
 import android.content.Context
-import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.os.ResultReceiver
@@ -20,8 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class NotificationManager internal constructor(private val context: Context, private val exoPlayer: ExoPlayer, private val event: NotificationEventHolder) :
-    PlayerNotificationManager.PrimaryActionReceiver, PlayerNotificationManager.NotificationListener {
+class NotificationManager internal constructor(private val context: Context, private val exoPlayer: ExoPlayer, private val event: NotificationEventHolder) : PlayerNotificationManager.NotificationListener {
     private lateinit var descriptionAdapter: DescriptionAdapter
     private var internalManager: PlayerNotificationManager? = null
 
@@ -61,103 +59,95 @@ class NotificationManager internal constructor(private val context: Context, pri
             }
         }
 
-    var showPlayPauseButton: Boolean
-        get() = internalManager?.usePlayPauseActions ?: false
+    var showPlayPauseButton = true
         set(value) {
             scope.launch {
-                internalManager?.usePlayPauseActions = value
+                field = value
+                internalManager?.setUsePlayPauseActions(value)
             }
         }
 
-    var showStopButton: Boolean
-        get() = internalManager?.useStopAction ?: false
+    var showStopButton = true
         set(value) {
             scope.launch {
-                internalManager?.useStopAction = value
+                field = value
+                internalManager?.setUseStopAction(value)
             }
         }
 
-    var showStopButtonCompact: Boolean
-        get() = internalManager?.useStopActionInCompactView ?: false
+    var showForwardButton = true
         set(value) {
             scope.launch {
-                internalManager?.useStopActionInCompactView = value
-            }
-        }
-
-    var showForwardButton: Boolean
-        get() = internalManager?.useFastForwardAction ?: false
-        set(value) {
-            scope.launch {
-                internalManager?.useFastForwardAction = value
+                field = value
+                internalManager?.setUseFastForwardAction(value)
             }
         }
 
     /**
      * Controls whether or not this button should appear when the notification is compact (collapsed).
      */
-    var showForwardButtonCompact: Boolean
-        get() = internalManager?.useFastForwardActionInCompactView ?: false
+    var showForwardButtonCompact = true
         set(value) {
             scope.launch {
-                internalManager?.useFastForwardActionInCompactView = value
+                field = value
+                internalManager?.setUseFastForwardActionInCompactView(value)
             }
         }
 
-    var showBackwardButton: Boolean
-        get() = internalManager?.useRewindAction ?: false
+    var showRewindButton = true
         set(value) {
             scope.launch {
-                internalManager?.useRewindAction = value
-            }
-        }
-
-    /**
-     * Controls whether or not this button should appear when the notification is compact (collapsed).
-     */
-    var showBackwardButtonCompact: Boolean
-        get() = internalManager?.useRewindActionInCompactView ?: false
-        set(value) {
-            scope.launch {
-                internalManager?.useRewindActionInCompactView = value
-            }
-        }
-
-    var showNextButton: Boolean
-        get() = internalManager?.useNextAction ?: false
-        set(value) {
-            scope.launch {
-                internalManager?.useNextAction = value
+                field = value
+                internalManager?.setUseRewindAction(value)
             }
         }
 
     /**
      * Controls whether or not this button should appear when the notification is compact (collapsed).
      */
-    var showNextButtonCompact: Boolean
-        get() = internalManager?.useNextActionInCompactView ?: false
+    var showRewindButtonCompact = true
         set(value) {
             scope.launch {
-                internalManager?.useNextActionInCompactView = value
+                field = value
+                internalManager?.setUseRewindActionInCompactView(value)
             }
         }
 
-    var showPreviousButton: Boolean
-        get() = internalManager?.usePreviousAction ?: false
+    var showNextButton = true
         set(value) {
             scope.launch {
-                internalManager?.usePreviousAction = value
+                field = value
+                internalManager?.setUseNextAction(value)
             }
         }
 
     /**
      * Controls whether or not this button should appear when the notification is compact (collapsed).
      */
-    var showPreviousButtonCompact: Boolean
-        get() = internalManager?.usePreviousActionInCompactView ?: false
+    var showNextButtonCompact = true
         set(value) {
             scope.launch {
-                internalManager?.usePreviousActionInCompactView = value
+                field = value
+                internalManager?.setUseNextActionInCompactView(value)
+            }
+        }
+
+    var showPreviousButton = true
+        set(value) {
+            scope.launch {
+                field = value
+                internalManager?.setUsePreviousAction(value)
+            }
+        }
+
+    /**
+     * Controls whether or not this button should appear when the notification is compact (collapsed).
+     */
+    var showPreviousButtonCompact = true
+        set(value) {
+            scope.launch {
+                field = value
+                internalManager?.setUsePreviousActionInCompactView(value)
             }
         }
 
@@ -207,7 +197,7 @@ class NotificationManager internal constructor(private val context: Context, pri
             setNotificationListener(this@NotificationManager)
 
             if (buttons.isNotEmpty()) {
-                setPrimaryActionReceiver(this@NotificationManager)
+//                setPrimaryActionReceiver(this@NotificationManager)
 
                 config.buttons.forEach { button ->
                     when (button) {
@@ -230,18 +220,19 @@ class NotificationManager internal constructor(private val context: Context, pri
 
                 config.buttons.forEach { button ->
                     when (button) {
-                        is NotificationButton.PLAY, is NotificationButton.PAUSE -> showPlayPauseButton = true
+                        is NotificationButton.PLAY, is NotificationButton.PAUSE -> {
+                            showPlayPauseButton = true
+                        }
                         is NotificationButton.STOP -> {
                             showStopButton = true
-                            showStopButtonCompact = button.isCompact
                         }
                         is NotificationButton.FORWARD -> {
                             showForwardButton = true
                             showForwardButtonCompact = button.isCompact
                         }
                         is NotificationButton.BACKWARD -> {
-                            showBackwardButton = true
-                            showBackwardButtonCompact = button.isCompact
+                            showRewindButton = true
+                            showRewindButtonCompact = button.isCompact
                         }
                         is NotificationButton.NEXT -> {
                             showNextButton = true
@@ -266,11 +257,11 @@ class NotificationManager internal constructor(private val context: Context, pri
         internalManager?.setPlayer(null)
     }
 
-    override fun onAction(player: Player, action: String, intent: Intent) {
-        scope.launch {
-            event.updateOnNotificationButtonTapped(NotificationButton.valueOf(action))
-        }
-    }
+//    override fun onAction(player: Player, action: String, intent: Intent) {
+//        scope.launch {
+//            event.updateOnNotificationButtonTapped(NotificationButton.valueOf(action))
+//        }
+//    }
 
     override fun onNotificationPosted(notificationId: Int, notification: Notification, ongoing: Boolean) {
         scope.launch {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -448,7 +448,6 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         }
 
         override fun onPause() {
-            Timber.d("PAUSE")
             playerEventHolder.updateOnMediaSessionCallbackTriggered(MediaSessionCallback.PAUSE)
         }
 

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -129,8 +129,8 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
     private var hasAudioFocus = false
     private var wasDucking = false
 
-    private val mediaSession = MediaSessionCompat(context, "KotlinAudioPlayer")
-    private val mediaSessionConnector = MediaSessionConnector(mediaSession)
+    protected val mediaSession = MediaSessionCompat(context, "KotlinAudioPlayer")
+    protected val mediaSessionConnector = MediaSessionConnector(mediaSession)
 
     init {
         if (cacheConfig != null) {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -421,13 +421,14 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
                 Player.MEDIA_ITEM_TRANSITION_REASON_SEEK -> playerEventHolder.updateAudioItemTransition(AudioItemTransitionReason.SEEK_TO_ANOTHER_AUDIO_ITEM(oldPosition))
             }
 
-            if (automaticallyUpdateNotificationMetadata)
-                mediaSessionConnector.setMediaMetadataProvider {
-                    val mediaSource = currentItem?.let { item -> getMediaSourceFromAudioItem(item) }
-                    mediaSource?.getMediaMetadataCompat() ?: MediaMetadataCompat.Builder().build()
+            if (automaticallyUpdateNotificationMetadata) {
+                notificationManager.notificationMetadata = NotificationMetadata(currentItem?.title, currentItem?.artist, currentItem?.artwork)
+            }
 
-                }
-            notificationManager.notificationMetadata = NotificationMetadata(currentItem?.title, currentItem?.artist, currentItem?.artwork)
+            mediaSessionConnector.setMediaMetadataProvider {
+                val mediaSource = currentItem?.let { item -> getMediaSourceFromAudioItem(item) }
+                mediaSource?.getMediaMetadataCompat() ?: MediaMetadataCompat.Builder().build()
+            }
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -6,6 +6,7 @@ import android.media.AudioManager.AUDIOFOCUS_LOSS
 import android.net.Uri
 import android.os.Bundle
 import android.os.ResultReceiver
+import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.RatingCompat
 import android.support.v4.media.session.MediaSessionCompat
 import androidx.annotation.CallSuper
@@ -190,12 +191,10 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
 
     fun play() {
         exoPlayer.play()
-//        notificationManager.onPlay()
     }
 
     fun pause() {
         exoPlayer.pause()
-//        notificationManager.onPause()
     }
 
     /**
@@ -403,8 +402,8 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
 
         override fun onPositionDiscontinuity(oldPosition: Player.PositionInfo, newPosition: Player.PositionInfo, reason: Int) {
             this@BaseAudioPlayer.oldPosition = oldPosition.positionMs
-            
-            when(reason) {
+
+            when (reason) {
                 Player.DISCONTINUITY_REASON_AUTO_TRANSITION -> playerEventHolder.updatePositionChangedReason(PositionChangedReason.AUTO(oldPosition.positionMs, newPosition.positionMs))
                 Player.DISCONTINUITY_REASON_SEEK -> playerEventHolder.updatePositionChangedReason(PositionChangedReason.SEEK(oldPosition.positionMs, newPosition.positionMs))
                 Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT -> playerEventHolder.updatePositionChangedReason(PositionChangedReason.SEEK_FAILED(oldPosition.positionMs, newPosition.positionMs))
@@ -423,7 +422,12 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
             }
 
             if (automaticallyUpdateNotificationMetadata)
-                notificationManager.notificationMetadata = NotificationMetadata(currentItem?.title, currentItem?.artist, currentItem?.artwork)
+                mediaSessionConnector.setMediaMetadataProvider {
+                    val mediaSource = currentItem?.let { item -> getMediaSourceFromAudioItem(item) }
+                    mediaSource?.getMediaMetadataCompat() ?: MediaMetadataCompat.Builder().build()
+
+                }
+            notificationManager.notificationMetadata = NotificationMetadata(currentItem?.title, currentItem?.artist, currentItem?.artwork)
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -197,11 +197,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         exoPlayer.pause()
     }
 
-    /**
-     * Stops playback, resetting the player and queue.
-     */
-    open fun stop() {
-        exoPlayer.stop()
+    open fun clearQueue() {
         exoPlayer.clearMediaItems()
     }
 
@@ -211,7 +207,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
     @CallSuper
     open fun destroy() {
         abandonAudioFocusIfHeld()
-        stop()
+        clearQueue()
         notificationManager.destroy()
         exoPlayer.release()
         cache?.release()

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -150,20 +150,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         mediaSession.setCallback(MediaSessionListener())
         exoPlayer.addListener(PlayerListener())
         mediaSessionConnector.setPlayer(exoPlayer)
-//        PlaybackStateCompat.Builder().addCustomAction()
-//        mediaSessionConnector.registerCustomCommandReceiver(object: MediaSessionConnector.CommandReceiver {
-//            override fun onCommand(player: Player, command: String, extras: Bundle?, cb: ResultReceiver?): Boolean {
-//                Timber.d(command)
-//                return true
-//            }
-//
-//        })
     }
-//
-//    override fun onMediaButtonEvent(mediaButtonEvent: Intent?): Boolean {
-//        Timber.d("WOW")
-//        return super.onMediaButtonEvent(mediaButtonEvent)
-//    }
 
     private fun setupBuffer(bufferConfig: BufferConfig): DefaultLoadControl {
         bufferConfig.apply {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -211,6 +211,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         notificationManager.destroy()
         exoPlayer.release()
         cache?.release()
+        mediaSession.isActive = false
     }
 
     fun seek(duration: Long, unit: TimeUnit) {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -150,6 +150,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
 
         mediaSession.setCallback(MediaSessionListener())
         exoPlayer.addListener(PlayerListener())
+        exoPlayer.stop()
         mediaSessionConnector.setPlayer(exoPlayer)
     }
 
@@ -197,7 +198,11 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         exoPlayer.pause()
     }
 
-    open fun clearQueue() {
+    /**
+     * Stops playback, resetting the player and the queue. To use the player again, simply add a new [AudioItem].
+     */
+    open fun stop() {
+        exoPlayer.stop()
         exoPlayer.clearMediaItems()
     }
 
@@ -207,7 +212,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
     @CallSuper
     open fun destroy() {
         abandonAudioFocusIfHeld()
-        clearQueue()
+        stop()
         notificationManager.destroy()
         exoPlayer.release()
         cache?.release()

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/MediaSourceExt.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/MediaSourceExt.kt
@@ -1,0 +1,18 @@
+package com.doublesymmetry.kotlinaudio.players
+
+import android.support.v4.media.MediaMetadataCompat
+import com.google.android.exoplayer2.source.MediaSource
+
+fun MediaSource.getMediaMetadataCompat(): MediaMetadataCompat {
+    val audioItem = mediaItem.localConfiguration?.tag as com.doublesymmetry.kotlinaudio.models.AudioItem?
+    val metadata = mediaItem.mediaMetadata
+    val title = metadata.title ?: audioItem?.title
+    val artist = metadata.artist ?: audioItem?.artist
+    val albumTitle = metadata.albumTitle ?: audioItem?.albumTitle
+
+    return MediaMetadataCompat.Builder()
+        .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist.toString())
+        .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title.toString())
+        .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, albumTitle.toString())
+        .build()
+}

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -1,15 +1,23 @@
 package com.doublesymmetry.kotlinaudio.players
 
 import android.content.Context
+import android.support.v4.media.MediaDescriptionCompat
+import android.support.v4.media.session.MediaSessionCompat
 import com.doublesymmetry.kotlinaudio.models.*
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.IllegalSeekPositionException
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.ext.mediasession.TimelineQueueNavigator
 import com.google.android.exoplayer2.source.MediaSource
 import java.util.*
 
 class QueuedAudioPlayer(context: Context, bufferConfig: BufferConfig? = null, cacheConfig: CacheConfig? = null) : BaseAudioPlayer(context, bufferConfig, cacheConfig) {
     private val queue = LinkedList<MediaSource>()
     override val playerOptions = QueuePlayerOptionsImpl(exoPlayer)
+
+    init {
+        mediaSessionConnector.setQueueNavigator(KotlinAudioQueueNavigator(mediaSession))
+    }
 
     val currentIndex
         get() = exoPlayer.currentWindowIndex
@@ -207,6 +215,14 @@ class QueuedAudioPlayer(context: Context, bufferConfig: BufferConfig? = null, ca
     override fun destroy() {
         queue.clear()
         super.destroy()
+    }
+
+    private inner class KotlinAudioQueueNavigator(mediaSession: MediaSessionCompat) : TimelineQueueNavigator(mediaSession) {
+        override fun getMediaDescription(player: Player, windowIndex: Int): MediaDescriptionCompat {
+            val item = items[windowIndex]
+
+            return item.mediaMetadataCompat.description
+        }
     }
 }
 

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -201,17 +201,11 @@ class QueuedAudioPlayer(context: Context, bufferConfig: BufferConfig? = null, ca
         queue.subList(0, currentIndex).clear()
     }
 
-    /**
-     * Stop playback, resetting the player and queue.
-     */
-    override fun clearQueue() {
-        super.clearQueue()
+    override fun stop() {
+        super.stop()
         queue.clear()
     }
 
-    /**
-     * Stops and resets the player, as well as clears the queue. Only call this when you are finished using the player, otherwise use [pause].
-     */
     override fun destroy() {
         queue.clear()
         super.destroy()

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -204,8 +204,8 @@ class QueuedAudioPlayer(context: Context, bufferConfig: BufferConfig? = null, ca
     /**
      * Stop playback, resetting the player and queue.
      */
-    override fun stop() {
-        super.stop()
+    override fun clearQueue() {
+        super.clearQueue()
         queue.clear()
     }
 

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -219,9 +219,9 @@ class QueuedAudioPlayer(context: Context, bufferConfig: BufferConfig? = null, ca
 
     private inner class KotlinAudioQueueNavigator(mediaSession: MediaSessionCompat) : TimelineQueueNavigator(mediaSession) {
         override fun getMediaDescription(player: Player, windowIndex: Int): MediaDescriptionCompat {
-            val item = items[windowIndex]
+            val item = queue[windowIndex]
 
-            return item.mediaMetadataCompat.description
+            return item.getMediaMetadataCompat().description
         }
     }
 }

--- a/kotlin-audio/src/main/res/values/strings.xml
+++ b/kotlin-audio/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="play">Play</string>
-    <string name="playback_channel_name">KotlinAudio Player</string>
+    <string name="playback_channel_name">Now Playing</string>
     <string name="pause">Pause</string>
 </resources>


### PR DESCRIPTION
1. This PR removes the ExoPlayer fork dependacy we had, fixing #17 and https://github.com/doublesymmetry/react-native-track-player/issues/1418
2. This PR will also enable bluetooth/physical button media control.
3. It provides Android with proper metadata for the current track, allowing it to populate lock screens and AODs. Can indirectly fix #27, but more tests need to be done.

The followup to this PR is https://github.com/doublesymmetry/react-native-track-player/pull/1651