### PR TITLE
fix(queue): do nothing when queue is empty

### DIFF
--- a/kotlin-audio-sample/src/androidTest/java/com/doublesymmetry/kotlin_audio_sample/QueuedAudioPlayerTest.kt
+++ b/kotlin-audio-sample/src/androidTest/java/com/doublesymmetry/kotlin_audio_sample/QueuedAudioPlayerTest.kt
@@ -127,6 +127,16 @@ class QueuedAudioPlayerTest {
     }
 
     @Test
+    fun nextItems_when_no_items_should_be_empty() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val audioPlayer = QueuedAudioPlayer(appContext)
+
+        audioPlayer.add(emptyList(), playWhenReady = false)
+        audioPlayer.removeUpcomingItems()
+        assertEquals(audioPlayer.nextItems.size, 0)
+    }
+
+    @Test
     fun nextItems_when_adding_two_items_then_stopping_should_be_empty() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val audioPlayer = QueuedAudioPlayer(appContext)

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -188,6 +188,7 @@ class QueuedAudioPlayer(context: Context, playerConfig: PlayerConfig = PlayerCon
      */
     fun removeUpcomingItems() {
         val lastIndex = queue.lastIndex
+        if (lastIndex == -1) return
 
         exoPlayer.removeMediaItems(currentIndex, lastIndex)
         queue.subList(currentIndex, lastIndex).clear()


### PR DESCRIPTION
This fixes an error when the queue is empty.

`queue.lastIndex` returns -1 when empty, so it would call `exoPlayer.removeMediaItems(0, -1)`, and the expo player implementation has an assertion that checks `lastIndex >= currentIndex`.

```
08-26 16:33:43.750 27413 27413 E AndroidRuntime: java.lang.IllegalArgumentException
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at com.google.android.exoplayer2.util.Assertions.checkArgument(Assertions.java:39)
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at com.google.android.exoplayer2.ExoPlayerImpl.removeMediaItemsInternal(ExoPlayerImpl.java:2189)
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at com.google.android.exoplayer2.ExoPlayerImpl.removeMediaItems(ExoPlayerImpl.java:655)
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at com.doublesymmetry.kotlinaudio.players.QueuedAudioPlayer.removeUpcomingItems(QueuedAudioPlayer.kt:192)
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at com.doublesymmetry.trackplayer.service.MusicService.removeUpcomingTracks(MusicService.kt:238)
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at com.doublesymmetry.trackplayer.module.MusicModule$removeUpcomingTracks$1.invokeSuspend(MusicModule.kt:328)
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
08-26 16:33:43.750 27413 27413 E AndroidRuntime: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
```

This would help solve an issue with react-native-track-player@3.1 [https://github.com/doublesymmetry/react-native-track-player/issues/1679](https://github.com/doublesymmetry/react-native-track-player/issues/1679).