### PR TITLE
Fix PAUSED state being emitted when buffering or on errors

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -490,9 +490,11 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            // onIsPlayingChanged with isPlaying = false triggers after player queue ends
-            // which sends a pause state after the STATE_ENDED - ignoring this case.
-            if (exoPlayer.playbackState == Player.STATE_ENDED && !isPlaying) return
+            // Unless ExoPlayer is in STATE_READY then it is either idle, buffering or the media has ended
+            // Without this check these other state will be immediately overridden by PLAYING/PAUSED
+            if (exoPlayer.playbackState != Player.STATE_READY) {
+                return
+            }
 
             playerState = if (isPlaying) AudioPlayerState.PLAYING else AudioPlayerState.PAUSED
             playerEventHolder.updateAudioPlayerState(


### PR DESCRIPTION
This fixes this issue with RNTP https://github.com/doublesymmetry/react-native-track-player/issues/1476

