### PR TITLE
Mimic ExoPlayer play notification behavior

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -243,6 +243,11 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
     }
 
     fun play() {
+        if (exoPlayer.playbackState == Player.STATE_IDLE) {
+            exoPlayer.prepare();
+        } else if (exoPlayer.playbackState == Player.STATE_ENDED) {
+            exoPlayer.seekToDefaultPosition(exoPlayer.currentMediaItemIndex);
+        }
         exoPlayer.play()
     }
 


### PR DESCRIPTION
On errors ExoPlayer transitions to IDLE and in this state calling play does nothing. However calling prepare tries to resume playback and is handy in cases where the player fails because of network errors.

I also copied the behavior on STATE_ENDED which is to replay the current media.
It seems logical to me, but it I'm not sure if that's the behavior we want. 

https://github.com/google/ExoPlayer/blob/f1b37bc547e7194354fe31e240afa8a8fb0b5c6c/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerNotificationManager.java#L1538-L1543

Testing in sample application:
1. First fix the audioUrl for second item in the queue (lordeSound). For example by using this url: https://file-examples.com/storage/fe7d3a0d44631509da1f416/2017/11/file_example_MP3_5MG.mp3
2. Disable wifi/data (for example by using airplane mode)
3. Click next to start the second track
4. Turn on wifi/data

Before this patch clicking play won't do anything and the player is stuck until new items are loaded.
After this patch play should resume playback as expected.