### PR TITLE
Retry playback on error forever for progressive sources

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -345,7 +345,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         return ProgressiveMediaSource.Factory(
             factory, DefaultExtractorsFactory()
                 .setConstantBitrateSeekingEnabled(true)
-        )
+        ).setLoadErrorHandlingPolicy(DefaultLoadErrorHandlingPolicy(Int.MAX_VALUE))
             .createMediaSource(mediaItem)
     }
 


### PR DESCRIPTION
I'm opening this PR as a discussion on a potential behavior change when playback stops because of exoplayer errors.

When e.g. playing long mp3 files over the network the whole file is usually not buffered which is expected.
The problem is when the user loses network connection and runs out of buffered media ExoPlayer will only retry playback for a fairly short time. After a few retries an error is emitted and the state transitions to idle. 
Currently there's no obvious way to resume playback when in idle, but this can be fixed by this related PR https://github.com/doublesymmetry/KotlinAudio/pull/47

However, in my use case it makes sense to retry for a much longer time as the user is likely to regain network connection and then wants to audio to continue playing.

The simplest fix is just to retry forever as I've done is this PR, but it might make more sense to either make this user configurable or just increase the retry count to something bigger. The default is 3. 

I only made the change for progressive media sources as I'm not sure if it also makes sense for streaming sources.