### PR TITLE
Fix for updating track metadata. Artwork was already updating, but no…

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -179,8 +179,14 @@ class QueuedAudioPlayer(context: Context, playerConfig: PlayerConfig = PlayerCon
         val mediaSource = getMediaSourceFromAudioItem(item)
         queue[index] = mediaSource
 
-        if (currentIndex == index && automaticallyUpdateNotificationMetadata)
-            notificationManager.notificationMetadata = NotificationMetadata(item.title, item.artist, item.artwork)
+        if (currentIndex == index && automaticallyUpdateNotificationMetadata) {
+            notificationManager.notificationMetadata =
+                NotificationMetadata(item.title, item.artist, item.artwork)
+
+            mediaSessionConnector.setMediaMetadataProvider {
+                mediaSource.getMediaMetadataCompat()
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
…t artist or title.

This mirrors the code in BaseAudioPlayer's onMediaItemTransition.

Fixes https://github.com/doublesymmetry/react-native-track-player/issues/1719