### PR TITLE
fix: speculative fix for SimpleCache crash

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -271,6 +271,7 @@ abstract class BaseAudioPlayer internal constructor(private val context: Context
         notificationManager.destroy()
         exoPlayer.release()
         cache?.release()
+        cache = null
         mediaSession.isActive = false
     }
 


### PR DESCRIPTION
This implements a speculative fix for the crash that occurs on hot-reload or if RN somehow still holds reference to the cash, described here: https://github.com/doublesymmetry/react-native-track-player/issues/296

Based on https://stackoverflow.com/a/58932800/4670489

