### PR TITLE
Clear artwork bitmap cache when updating notification metadata

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -6,10 +6,7 @@ import android.graphics.Color
 import android.support.v4.media.session.MediaSessionCompat
 import com.doublesymmetry.kotlinaudio.R
 import com.doublesymmetry.kotlinaudio.event.NotificationEventHolder
-import com.doublesymmetry.kotlinaudio.models.NotificationButton
-import com.doublesymmetry.kotlinaudio.models.NotificationConfig
-import com.doublesymmetry.kotlinaudio.models.NotificationMetadata
-import com.doublesymmetry.kotlinaudio.models.NotificationState
+import com.doublesymmetry.kotlinaudio.models.*
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector
 import com.google.android.exoplayer2.ui.PlayerNotificationManager
@@ -30,6 +27,13 @@ class NotificationManager internal constructor(
 
     var notificationMetadata: NotificationMetadata? = null
         set(value) {
+            // Clear bitmap cache if artwork changes
+            if (field?.artworkUrl != value?.artworkUrl) {
+                val itemHolder = player.currentMediaItem?.localConfiguration?.tag as AudioItemHolder?
+                if (itemHolder != null) {
+                    itemHolder.artworkBitmap = null
+                }
+            }
             field = value
             reload()
         }


### PR DESCRIPTION
See https://github.com/doublesymmetry/react-native-track-player/issues/1719#issuecomment-1414462721