### PR TITLE
Set playWhenReady to false when playback ends.

### DIFF
--- a/kotlin-audio/src/androidTest/java/com/doublesymmetry/kotlinaudio/QueuedAudioPlayerTest.kt
+++ b/kotlin-audio/src/androidTest/java/com/doublesymmetry/kotlinaudio/QueuedAudioPlayerTest.kt
@@ -321,7 +321,7 @@ class QueuedAudioPlayerTest {
                     assertEquals(1, testPlayer.previousItems.size)
                     assertEquals(0, testPlayer.nextItems.size)
                     assertEquals(second, testPlayer.currentItem)
-                    assertEquals(AudioPlayerState.ENDED, testPlayer.playerState)
+                    assertEquals(mutableListOf<String>("IDLE", "LOADING", "PLAYING", "LOADING", "PLAYING", "ENDED"), states);
                 })
             }
 
@@ -375,7 +375,7 @@ class QueuedAudioPlayerTest {
                     eventually(Duration.ofSeconds(30), Dispatchers.Main, fun() {
                         assertTrue(testPlayer.nextItems.isEmpty())
                         assertEquals(TestSound.short, testPlayer.currentItem)
-                        assertEquals(AudioPlayerState.ENDED, testPlayer.playerState)
+                        assertEquals(mutableListOf<String>("IDLE", "LOADING", "PLAYING", "LOADING", "PLAYING", "ENDED"), states);
                     })
                 }
 

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -75,6 +75,14 @@ abstract class BaseAudioPlayer internal constructor(
             if (value != field) {
                 field = value
                 playerEventHolder.updateAudioPlayerState(value)
+                val playbackStopped = arrayOf(
+                    AudioPlayerState.ERROR,
+                    AudioPlayerState.ENDED,
+                    AudioPlayerState.STOPPED
+                ).contains(value)
+                if (playbackStopped) {
+                    this.playWhenReady = false
+                }
                 if (!playerConfig.handleAudioFocus) {
                     when (value) {
                         AudioPlayerState.IDLE,
@@ -345,7 +353,6 @@ abstract class BaseAudioPlayer internal constructor(
      */
     open fun stop() {
         playerState = AudioPlayerState.STOPPED
-        exoPlayer.playWhenReady = false
         exoPlayer.stop()
     }
 
@@ -677,7 +684,11 @@ abstract class BaseAudioPlayer internal constructor(
                         }
                     }
                     Player.EVENT_PLAY_WHEN_READY_CHANGED -> {
-                        if (!player.playWhenReady && playerState != AudioPlayerState.STOPPED) {
+                        if (!player.playWhenReady && !arrayOf(
+                                AudioPlayerState.ERROR,
+                                AudioPlayerState.ENDED,
+                                AudioPlayerState.STOPPED
+                            ).contains(playerState)) {
                             playerState = AudioPlayerState.PAUSED
                         }
                     }


### PR DESCRIPTION
`playWhenReady` becomes false when playback ends due to `stop()` being called, when a playback error occurs or when the queue ends