### PR TITLE
Partial migration to media3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 16 18:14:46 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/kotlin-audio-sample/build.gradle
+++ b/kotlin-audio-sample/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.doublesymmetry.kotlin_audio_sample"
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -32,6 +32,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.doublesymmetry.kotlin_audio_sample'
 }
 
 dependencies {

--- a/kotlin-audio-sample/src/main/AndroidManifest.xml
+++ b/kotlin-audio-sample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.doublesymmetry.kotlin_audio_sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     

--- a/kotlin-audio/build.gradle
+++ b/kotlin-audio/build.gradle
@@ -11,11 +11,11 @@ group = 'com.github.doublesymmetry'
 version = versionNumber
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["runnerBuilder"] = "de.mannodermaus.junit5.AndroidJUnit5Builder"
@@ -34,13 +34,17 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.doublesymmetry.kotlinaudio'
 }
 
 dependencies {
     implementation 'io.coil-kt:coil:1.4.0'
-    implementation 'androidx.media:media:1.6.0'
-    api 'com.google.android.exoplayer:exoplayer:2.18.1'
-    api 'com.google.android.exoplayer:extension-mediasession:2.18.1'
+    implementation 'androidx.media3:media3-exoplayer:1.0.0-beta03'
+    implementation 'androidx.media3:media3-exoplayer-dash:1.0.0-beta03'
+    implementation 'androidx.media3:media3-exoplayer-hls:1.0.0-beta03'
+    implementation 'androidx.media3:media3-exoplayer-smoothstreaming:1.0.0-beta03'
+    implementation 'androidx.media3:media3-session:1.0.0-beta03'
+    api 'androidx.media3:media3-ui:1.0.0-beta03'
     api 'com.jakewharton.timber:timber:5.0.1'
 
     implementation 'androidx.test:rules:1.4.0'

--- a/kotlin-audio/src/main/AndroidManifest.xml
+++ b/kotlin-audio/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.doublesymmetry.kotlinaudio" />
+<manifest />

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/MediaSessionCallback.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/MediaSessionCallback.kt
@@ -1,10 +1,10 @@
 package com.doublesymmetry.kotlinaudio.models
 
 import android.os.Bundle
-import android.support.v4.media.RatingCompat
+//import android.support.v4.media.RatingCompat
 
 sealed class MediaSessionCallback {
-    class RATING(val rating: RatingCompat, extras: Bundle?): MediaSessionCallback()
+//    class RATING(val rating: RatingCompat, extras: Bundle?): MediaSessionCallback()
     object PLAY : MediaSessionCallback()
     object PAUSE : MediaSessionCallback()
     object NEXT : MediaSessionCallback()

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayWhenReadyChangeData.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayWhenReadyChangeData.kt
@@ -1,5 +1,3 @@
 package com.doublesymmetry.kotlinaudio.models
 
-import com.google.android.exoplayer2.Player
-
 data class PlayWhenReadyChangeData(val playWhenReady: Boolean, val pausedBecauseReachedEnd: Boolean)

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlaybackMetadata.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlaybackMetadata.kt
@@ -1,12 +1,12 @@
 package com.doublesymmetry.kotlinaudio.models
 
-import com.google.android.exoplayer2.metadata.Metadata
-import com.google.android.exoplayer2.metadata.flac.VorbisComment
-import com.google.android.exoplayer2.metadata.icy.IcyHeaders
-import com.google.android.exoplayer2.metadata.icy.IcyInfo
-import com.google.android.exoplayer2.metadata.id3.TextInformationFrame
-import com.google.android.exoplayer2.metadata.id3.UrlLinkFrame
-import com.google.android.exoplayer2.metadata.mp4.MdtaMetadataEntry
+import androidx.media3.extractor.metadata.id3.TextInformationFrame
+import androidx.media3.common.Metadata
+import androidx.media3.extractor.metadata.icy.IcyHeaders
+import androidx.media3.extractor.metadata.icy.IcyInfo
+import androidx.media3.extractor.metadata.id3.UrlLinkFrame
+import androidx.media3.extractor.metadata.mp4.MdtaMetadataEntry
+import androidx.media3.extractor.metadata.vorbis.VorbisComment
 
 data class PlaybackMetadata(
     val source: String,

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayerConfig.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayerConfig.kt
@@ -1,8 +1,5 @@
 package com.doublesymmetry.kotlinaudio.models
 
-import com.google.android.exoplayer2.C
-import com.doublesymmetry.kotlinaudio.models.AudioContentType
-
 data class PlayerConfig(
     /**
      * Toggle whether or not a player action triggered from an outside source should be intercepted.

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/QueuedPlayerOptions.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/QueuedPlayerOptions.kt
@@ -1,7 +1,7 @@
 package com.doublesymmetry.kotlinaudio.models
 
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.Player
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
 
 interface QueuedPlayerOptions : PlayerOptions {
     override var alwaysPauseOnInterruption: Boolean

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/DescriptionAdapter.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/DescriptionAdapter.kt
@@ -6,13 +6,13 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
+import androidx.media3.common.Player
+import androidx.media3.ui.PlayerNotificationManager
 import coil.imageLoader
 import coil.request.Disposable
 import coil.request.ImageRequest
 import com.doublesymmetry.kotlinaudio.models.AudioItem
 import com.doublesymmetry.kotlinaudio.models.AudioItemHolder
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.ui.PlayerNotificationManager
 
 interface NotificationMetadataProvider {
     fun getTitle(): String?

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -3,21 +3,20 @@ package com.doublesymmetry.kotlinaudio.notification
 import android.app.Notification
 import android.content.Context
 import android.graphics.Color
-import android.support.v4.media.session.MediaSessionCompat
+import androidx.media3.common.Player
+import androidx.media3.session.MediaSession
+import androidx.media3.session.SessionToken
+import androidx.media3.ui.PlayerNotificationManager
 import com.doublesymmetry.kotlinaudio.R
 import com.doublesymmetry.kotlinaudio.event.NotificationEventHolder
 import com.doublesymmetry.kotlinaudio.models.*
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector
-import com.google.android.exoplayer2.ui.PlayerNotificationManager
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 
 class NotificationManager internal constructor(
     private val context: Context,
     private val player: Player,
-    private val mediaSessionToken: MediaSessionCompat.Token,
-    private val mediaSessionConnector: MediaSessionConnector,
+    private val mediaSession: MediaSession,
     val event: NotificationEventHolder
     ) : PlayerNotificationManager.NotificationListener {
     private lateinit var descriptionAdapter: DescriptionAdapter
@@ -213,7 +212,6 @@ class NotificationManager internal constructor(
                 }
             }
 
-            setMediaSessionToken(mediaSessionToken)
             setPlayer(player)
         }
     }
@@ -241,8 +239,8 @@ class NotificationManager internal constructor(
 
     private fun reload() = scope.launch {
         internalNotificationManager?.invalidate()
-        mediaSessionConnector.invalidateMediaSessionQueue()
-        mediaSessionConnector.invalidateMediaSessionMetadata()
+//        mediaSession.invalidateMediaSessionQueue()
+//        mediaSession.invalidateMediaSessionMetadata()
     }
 
     private fun hideAllButtonsByDefault() {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -3,21 +3,18 @@ package com.doublesymmetry.kotlinaudio.players
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import android.media.MediaMetadata.METADATA_KEY_ARTIST
+import android.media.MediaMetadata.METADATA_KEY_TITLE
 import android.os.Bundle
-import android.support.v4.media.MediaDescriptionCompat
-import android.support.v4.media.MediaMetadataCompat
-import android.support.v4.media.RatingCompat
-import android.support.v4.media.session.MediaSessionCompat
+import androidx.media3.common.C
+import androidx.media3.common.IllegalSeekPositionException
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.session.MediaSession
 import coil.imageLoader
 import coil.request.Disposable
 import coil.request.ImageRequest
 import com.doublesymmetry.kotlinaudio.models.*
-import com.doublesymmetry.kotlinaudio.players.components.getMediaMetadataCompat
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.IllegalSeekPositionException
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.ext.mediasession.TimelineQueueNavigator
-import com.google.android.exoplayer2.source.MediaSource
+
 import java.util.*
 import kotlin.math.max
 import kotlin.math.min
@@ -27,8 +24,8 @@ class QueuedAudioPlayer(context: Context, playerConfig: PlayerConfig = PlayerCon
     override val playerOptions = DefaultQueuedPlayerOptions(exoPlayer)
 
     init {
-        mediaSessionConnector.setQueueNavigator(KotlinAudioQueueNavigator(mediaSession))
-        mediaSessionConnector.setMetadataDeduplicationEnabled(true)
+//        mediaSessionConnector.setQueueNavigator(KotlinAudioQueueNavigator(mediaSession))
+//        mediaSessionConnector.setMetadataDeduplicationEnabled(true)
     }
 
     val currentIndex
@@ -263,50 +260,50 @@ class QueuedAudioPlayer(context: Context, playerConfig: PlayerConfig = PlayerCon
         super.clear()
     }
 
-    private inner class KotlinAudioQueueNavigator(mediaSession: MediaSessionCompat) : TimelineQueueNavigator(mediaSession) {
-        override fun getMediaDescription(player: Player, windowIndex: Int): MediaDescriptionCompat {
-            val isActive = windowIndex == player.currentMediaItemIndex
-            val mediaItem = queue[windowIndex].mediaItem
-            val audioItemHolder = (mediaItem.localConfiguration?.tag as AudioItemHolder)
-            val audioItem = audioItemHolder.audioItem
-            val metadata = mediaItem.mediaMetadata
-            var title = metadata.title ?: audioItem.title
-            var artist = metadata.artist ?: audioItem.artist
-            var artworkUrl = (audioItem.artwork ?: metadata.artworkUri)?.toString()
-            val notificationMetadata = notificationManager.notificationMetadata
-            if (isActive && notificationMetadata != null) {
-                title = notificationMetadata.title ?: title
-                artist = notificationMetadata.artist ?: artist
-                artworkUrl = notificationMetadata.artworkUrl ?: artworkUrl
-            }
-            if (
-                isActive &&
-                artworkUrl != null &&
-                audioItemHolder.artworkBitmap == null
-            ) {
-                context.imageLoader.enqueue(
-                    ImageRequest.Builder(context)
-                        .data(artworkUrl)
-                        .target {
-                            audioItemHolder.artworkBitmap = (it as BitmapDrawable).bitmap
-                            mediaSessionConnector.invalidateMediaSessionQueue()
-                            mediaSessionConnector.invalidateMediaSessionMetadata()
-                        }
-                        .build()
-                )
-            }
-
-            return MediaDescriptionCompat.Builder().apply {
-                setTitle(title)
-                setSubtitle(artist)
-                if (audioItemHolder.artworkBitmap != null) {
-                    setIconBitmap(audioItemHolder.artworkBitmap)
-                }
-                setExtras(Bundle().apply{
-                    putString(MediaMetadataCompat.METADATA_KEY_TITLE, title as String?)
-                    putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist as String?)
-                })
-            }.build()
-        }
-    }
+//    private inner class KotlinAudioQueueNavigator(mediaSession: MediaSession) : TimelineQueueNavigator(mediaSession) {
+//        override fun getMediaDescription(player: Player, windowIndex: Int): MediaDescriptionCompat {
+//            val isActive = windowIndex == player.currentMediaItemIndex
+//            val mediaItem = queue[windowIndex].mediaItem
+//            val audioItemHolder = (mediaItem.localConfiguration?.tag as AudioItemHolder)
+//            val audioItem = audioItemHolder.audioItem
+//            val metadata = mediaItem.mediaMetadata
+//            var title = metadata.title ?: audioItem.title
+//            var artist = metadata.artist ?: audioItem.artist
+//            var artworkUrl = (audioItem.artwork ?: metadata.artworkUri)?.toString()
+//            val notificationMetadata = notificationManager.notificationMetadata
+//            if (isActive && notificationMetadata != null) {
+//                title = notificationMetadata.title ?: title
+//                artist = notificationMetadata.artist ?: artist
+//                artworkUrl = notificationMetadata.artworkUrl ?: artworkUrl
+//            }
+//            if (
+//                isActive &&
+//                artworkUrl != null &&
+//                audioItemHolder.artworkBitmap == null
+//            ) {
+//                context.imageLoader.enqueue(
+//                    ImageRequest.Builder(context)
+//                        .data(artworkUrl)
+//                        .target {
+//                            audioItemHolder.artworkBitmap = (it as BitmapDrawable).bitmap
+////                            mediaSessionConnector.invalidateMediaSessionQueue()
+////                            mediaSessionConnector.invalidateMediaSessionMetadata()
+//                        }
+//                        .build()
+//                )
+//            }
+//
+//            return MediaDescriptionCompat.Builder().apply {
+//                setTitle(title)
+//                setSubtitle(artist)
+//                if (audioItemHolder.artworkBitmap != null) {
+//                    setIconBitmap(audioItemHolder.artworkBitmap)
+//                }
+//                setExtras(Bundle().apply{
+//                    putString(METADATA_KEY_TITLE, title as String?)
+//                    putString(METADATA_KEY_ARTIST, artist as String?)
+//                })
+//            }.build()
+//        }
+//    }
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/components/MediaSourceExt.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/components/MediaSourceExt.kt
@@ -1,14 +1,19 @@
 package com.doublesymmetry.kotlinaudio.players.components
 
+import android.media.MediaMetadata.METADATA_KEY_ALBUM
+import android.media.MediaMetadata.METADATA_KEY_ARTIST
+import android.media.MediaMetadata.METADATA_KEY_DURATION
+import android.media.MediaMetadata.METADATA_KEY_GENRE
+import android.media.MediaMetadata.METADATA_KEY_TITLE
 import android.net.Uri
 import android.os.Bundle
-import android.support.v4.media.MediaDescriptionCompat
-import android.support.v4.media.MediaMetadataCompat
-import android.support.v4.media.RatingCompat
+import androidx.media3.common.MediaMetadata
+//import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Rating
+import androidx.media3.exoplayer.source.MediaSource
 import com.doublesymmetry.kotlinaudio.models.AudioItemHolder
-import com.google.android.exoplayer2.source.MediaSource
 
-fun MediaSource.getMediaMetadataCompat(): MediaMetadataCompat {
+fun MediaSource.getMediaMetadata(): MediaMetadata {
     val audioItem = (mediaItem.localConfiguration?.tag as AudioItemHolder?)?.audioItem
     val metadata = mediaItem.mediaMetadata
     val title = metadata.title ?: audioItem?.title
@@ -17,21 +22,20 @@ fun MediaSource.getMediaMetadataCompat(): MediaMetadataCompat {
     val genre = metadata.genre
     val duration = audioItem?.duration ?: -1
     val artwork = metadata.artworkUri ?: audioItem?.artwork
-    val rating = RatingCompat.fromRating(metadata.userRating)
+    val rating = metadata.userRating
 
-    return MediaMetadataCompat.Builder().apply {
-        putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist.toString())
-        putString(MediaMetadataCompat.METADATA_KEY_TITLE, title.toString())
-        putString(MediaMetadataCompat.METADATA_KEY_ALBUM, albumTitle.toString())
-        putString(MediaMetadataCompat.METADATA_KEY_GENRE, genre.toString())
-        putLong(MediaMetadataCompat.METADATA_KEY_DURATION, duration)
+    return MediaMetadata.Builder().apply {
+        setArtist(artist.toString())
+        setTitle(title.toString())
+        setAlbumTitle(albumTitle.toString())
+        setGenre(genre.toString())
 
         if (artwork != null) {
-            putString(MediaMetadataCompat.METADATA_KEY_ART_URI, artwork.toString())
+            setArtworkUri(artwork as Uri?)
         }
 
         if (rating != null) {
-            putRating(MediaMetadataCompat.METADATA_KEY_RATING, rating)
+            setUserRating(rating)
         }
     }.build()
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/components/PlayerCache.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/components/PlayerCache.kt
@@ -1,11 +1,11 @@
 package com.doublesymmetry.kotlinaudio.players.components
 
 import android.content.Context
+import androidx.media3.database.DatabaseProvider
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
 import com.doublesymmetry.kotlinaudio.models.CacheConfig
-import com.google.android.exoplayer2.database.DatabaseProvider
-import com.google.android.exoplayer2.database.StandaloneDatabaseProvider
-import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor
-import com.google.android.exoplayer2.upstream.cache.SimpleCache
 import java.io.File
 
 object PlayerCache {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
@@ -2,7 +2,7 @@ package com.doublesymmetry.kotlinaudio.utils
 
 import android.content.ContentResolver
 import android.net.Uri
-import com.google.android.exoplayer2.upstream.RawResourceDataSource
+import androidx.media3.datasource.RawResourceDataSource
 
 fun isUriLocal(uri: Uri?): Boolean {
     if (uri == null) return false


### PR DESCRIPTION
Spent a moment looking at migrating to media3 using the following migration guide: https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide

Unfinished bits:
- MediaSessionCallback.RATING
- NotificationManager: mediaSessionConnector.invalidateMediaSessionQueue() / mediaSession.invalidateMediaSessionMetadata() functionality
- BaseAudioPlayer ratingType
- BaseAudioPlayer requestAudioFocus / releaseAudioFocus
- QueuedAudioPlayer init: setQueueNavigator / setMetadataDeduplicationEnabled
