### PR TITLE
Fix triggering of MediaSessionCallback.STOP

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -263,6 +263,10 @@ abstract class BaseAudioPlayer internal constructor(
                 playerEventHolder.updateOnPlayerActionTriggeredExternally(MediaSessionCallback.STOP)
             }
 
+            override fun stop(reset: Boolean) {
+                playerEventHolder.updateOnPlayerActionTriggeredExternally(MediaSessionCallback.STOP)
+            }
+
             override fun seekTo(positionMs: Long) {
                 playerEventHolder.updateOnPlayerActionTriggeredExternally(
                     MediaSessionCallback.SEEK(


### PR DESCRIPTION
Fixes the following react native track player issue: https://github.com/doublesymmetry/react-native-track-player/issues/1889