### PR TITLE
Fix: only pass relevant actions in getCustomActions

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -256,8 +256,23 @@ class NotificationManager internal constructor(
             )
         }
 
-        override fun getCustomActions(player: Player): MutableList<String> {
-            return mutableListOf(STOP, REWIND, FORWARD)
+        override fun getCustomActions(player: Player): List<String> {
+            return buttons.mapNotNull {
+                when (it) {
+                    is NotificationButton.STOP -> {
+                        STOP
+                    }
+                    is NotificationButton.FORWARD -> {
+                        FORWARD
+                    }
+                    is NotificationButton.BACKWARD -> {
+                        REWIND
+                    }
+                    else -> {
+                        null
+                    }
+                }
+            }
         }
 
         override fun onCustomAction(player: Player, action: String, intent: Intent) {


### PR DESCRIPTION
This should fix https://github.com/doublesymmetry/react-native-track-player/issues/1970