### PR TITLE
fix: reset media player notification in createNotification

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -300,9 +300,13 @@ class NotificationManager internal constructor(
     /**
      * Create a media player notification that automatically updates.
      *
-     * **NOTE:** You should only call this once. Subsequent calls will result in an error.
      */
     fun createNotification(config: NotificationConfig) = scope.launch {
+        if(internalNotificationManager != null){
+            hideNotification() // reset media player notification
+            delay(200) // minimum delay to reset and repopulate the media player notification
+        }
+
         buttons.apply {
             clear()
             addAll(config.buttons)


### PR DESCRIPTION
This fix resolved [this issue](https://github.com/DoubleSymmetry/react-native-track-player/issues/1419) in react-native-track-player