### PR TITLE
Fix audio player state not becoming AudioPlayerState.IDLE when queue emptied

### DIFF
--- a/kotlin-audio/src/androidTest/java/com/doublesymmetry/kotlinaudio/QueuedAudioPlayerTest.kt
+++ b/kotlin-audio/src/androidTest/java/com/doublesymmetry/kotlinaudio/QueuedAudioPlayerTest.kt
@@ -879,6 +879,15 @@ class QueuedAudioPlayerTest {
                 assertEquals(0, testPlayer.currentIndex)
                 assertEquals(null, testPlayer.currentItem)
             }
+
+        @Test
+        fun givenAddedThreeItemsAndDeletingAll_thenPlayerStateShouldBecomeIDLE() =
+            runBlocking(Dispatchers.Main) {
+                testPlayer.remove(listOf(0, 1, 2))
+                eventually(Duration.ofSeconds(30), Dispatchers.Main, fun () {
+                    assertEquals(AudioPlayerState.IDLE, testPlayer.playerState)
+                });
+            }
     }
 
     @Nested

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioPlayerState.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioPlayerState.kt
@@ -22,7 +22,7 @@ enum class AudioPlayerState {
     /** No [AudioItem] is loaded and the player is doing nothing. */
     IDLE,
 
-    /** The player has finished playing all the [AudioItem]s. TODO: Add additional info */
+    /** Playback stopped due to the end of the queue being reached. */
     ENDED,
 
     /** The player stopped playing due to an error. */

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -677,7 +677,9 @@ abstract class BaseAudioPlayer internal constructor(
                                     null
                                 else
                                     AudioPlayerState.IDLE
-                            Player.STATE_ENDED -> AudioPlayerState.ENDED
+                            Player.STATE_ENDED ->
+                                if (player.mediaItemCount > 0) AudioPlayerState.ENDED
+                                else AudioPlayerState.IDLE
                             else -> null // noop
                         }
                         if (state != null && state != playerState) {


### PR DESCRIPTION
- when queue becomes empty, make player state become `AudioPlayerState.IDLE` (which denotes “No AudioItem is loaded and the player is doing nothing.”) instead of `AudioPlayerState.ENDED` which denotes `Playback stopped due to the end of the queue being reached.`
- change docs for `AudioPlayerState.ENDED`
- add test