### PR TITLE
Ensure new track plays from start after replacement

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -63,8 +63,8 @@ class QueuedAudioPlayer(
         get() = items.getOrNull(currentIndex - 1)
 
     override fun load(item: AudioItem, playWhenReady: Boolean) {
-        exoPlayer.playWhenReady = playWhenReady
         load(item)
+        exoPlayer.playWhenReady = playWhenReady
     }
 
     override fun load(item: AudioItem) {
@@ -75,6 +75,7 @@ class QueuedAudioPlayer(
             queue[currentIndex] = mediaSource
             exoPlayer.addMediaSource(currentIndex + 1, mediaSource)
             exoPlayer.removeMediaItem(currentIndex)
+            exoPlayer.seekTo(currentIndex, C.TIME_UNSET);
             exoPlayer.prepare()
         }
     }


### PR DESCRIPTION
Added a seek operation to reset the playback position when replacing a track in ExoPlayer. Previously, after replacing a track while in Player.STATE_ENDED, the player would maintain its position at the end of the old track. By seeking to the start of the newly added track, we ensure that playback begins from the beginning of the new media item.

This fixes an issue in rntp where:
- First adding a single track and playing it.
- Waiting for the track to end.
- Then calling `Trackplayer.load(otherTrack)` and `Trackplayer.play()`
- The new track would not start playing.