### PR TITLE
feat: square crop albumart option

### DIFF
--- a/kotlin-audio-example/src/main/java/com/example/kotlin_audio_example/MainActivity.kt
+++ b/kotlin-audio-example/src/main/java/com/example/kotlin_audio_example/MainActivity.kt
@@ -61,7 +61,8 @@ class MainActivity : ComponentActivity() {
             this, playerConfig = PlayerConfig(
                 interceptPlayerActionsTriggeredExternally = true,
                 handleAudioBecomingNoisy = true,
-                handleAudioFocus = true
+                handleAudioFocus = true,
+                // squareCropAlbumArt = true,
             )
         )
         player.add(tracks)
@@ -173,6 +174,14 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         val tracks = listOf(
+        DefaultAudioItem(
+                "https://rntp.dev/example/Longing.mp3",
+            MediaType.DEFAULT,
+            title = "Longing (wide album art)",
+            artwork = "https://i.ytimg.com/vi/qod7eBE0mTk/maxresdefault.jpg",
+            artist = "David Chavez",
+            duration = 143 * 1000,
+        ),
             DefaultAudioItem(
                 "https://rntp.dev/example/Longing.mp3",
                 MediaType.DEFAULT,

--- a/kotlin-audio/build.gradle
+++ b/kotlin-audio/build.gradle
@@ -64,6 +64,9 @@ dependencies {
     // The instrumentation test companion libraries
     androidTestImplementation("de.mannodermaus.junit5:android-test-core:1.3.0")
     androidTestRuntimeOnly("de.mannodermaus.junit5:android-test-runner:1.3.0")
+
+    // album art transformation
+    implementation 'jp.wasabeef.transformers:coil:1.0.6'
 }
 
 afterEvaluate {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayerConfig.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayerConfig.kt
@@ -30,4 +30,8 @@ data class PlayerConfig(
      * The audio content type.
      */
     val audioContentType: AudioContentType = AudioContentType.MUSIC,
+    /**
+     * Whether to crop the album art to a square.
+     */
+    val squareCropAlbumArt: Boolean = false,
 )

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -38,6 +38,7 @@ import com.google.android.exoplayer2.ui.PlayerNotificationManager.CustomActionRe
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import jp.wasabeef.transformers.coil.CropSquareTransformation
 
 class NotificationManager internal constructor(
     private val context: Context,
@@ -45,7 +46,8 @@ class NotificationManager internal constructor(
     private val mediaSession: MediaSessionCompat,
     private val mediaSessionConnector: MediaSessionConnector,
     val event: NotificationEventHolder,
-    val playerEventHolder: PlayerEventHolder
+    val playerEventHolder: PlayerEventHolder,
+    private val squareCropAlbumArt: Boolean,
 ) : PlayerNotificationManager.NotificationListener {
     private var pendingIntent: PendingIntent? = null
     private val descriptionAdapter = object : PlayerNotificationManager.MediaDescriptionAdapter {
@@ -76,10 +78,13 @@ class NotificationManager internal constructor(
             val artwork = getMediaItemArtworkUrl()
             val holder = player.currentMediaItem?.getAudioItemHolder()
             if (artwork != null && holder?.artworkBitmap == null) {
-                context.imageLoader.enqueue(
-                    ImageRequest.Builder(context)
+                var imageRequest = ImageRequest.Builder(context)
                         .data(artwork)
-                        .target { result ->
+                        if (squareCropAlbumArt) {
+                            imageRequest = imageRequest.transformations(CropSquareTransformation())
+                        }
+                context.imageLoader.enqueue(
+                        imageRequest.target { result ->
                             val resultBitmap = (result as BitmapDrawable).bitmap
                             holder?.artworkBitmap = resultBitmap
                             invalidate()

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -236,7 +236,8 @@ abstract class BaseAudioPlayer internal constructor(
             mediaSession,
             mediaSessionConnector,
             notificationEventHolder,
-            playerEventHolder
+            playerEventHolder,
+            playerConfig.squareCropAlbumArt
         )
 
         exoPlayer.addListener(PlayerListener())


### PR DESCRIPTION
this PR adds an option to crop the album art into a square, so android < 13 and Samsung users will see the squared album art spanning their notif area, instead of a wide one with while spaces on top and bottom.
closes #79 
issue is probably better described here (by the flutter colleagues):
https://github.com/ryanheise/audio_service/issues/1035
