### PR TITLE
Use http datasource for local urls

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -37,7 +37,7 @@ import com.doublesymmetry.kotlinaudio.models.PositionChangedReason
 import com.doublesymmetry.kotlinaudio.notification.NotificationManager
 import com.doublesymmetry.kotlinaudio.players.components.PlayerCache
 import com.doublesymmetry.kotlinaudio.players.components.getAudioItemHolder
-import com.doublesymmetry.kotlinaudio.utils.isUriLocal
+import com.doublesymmetry.kotlinaudio.utils.isUriLocalFile
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.DefaultLoadControl
 import com.google.android.exoplayer2.DefaultLoadControl.Builder
@@ -459,7 +459,7 @@ abstract class BaseAudioPlayer internal constructor(
                 raw.open(DataSpec(uri))
                 DataSource.Factory { raw }
             }
-            isUriLocal(uri) -> {
+            isUriLocalFile(uri) -> {
                 DefaultDataSourceFactory(context, userAgent)
             }
             else -> {

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
@@ -4,9 +4,13 @@ import android.content.ContentResolver
 import android.net.Uri
 import com.google.android.exoplayer2.upstream.RawResourceDataSource
 
-fun isUriLocal(uri: Uri?): Boolean {
+fun isUriLocalFile(uri: Uri?): Boolean {
     if (uri == null) return false
     val scheme = uri.scheme
     val host = uri.host
+    if((scheme == "http" || scheme == "https") && (host == "localhost" || host == "127.0.0.1" || host == "[::1]"))
+    {
+        return false
+    }
     return scheme == null || scheme == ContentResolver.SCHEME_FILE || scheme == ContentResolver.SCHEME_ANDROID_RESOURCE || scheme == ContentResolver.SCHEME_CONTENT || scheme == RawResourceDataSource.RAW_RESOURCE_SCHEME || scheme == "res" || host == null || host == "localhost" || host == "127.0.0.1" || host == "[::1]"
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
@@ -12,5 +12,5 @@ fun isUriLocalFile(uri: Uri?): Boolean {
     {
         return false
     }
-    return scheme == null || scheme == ContentResolver.SCHEME_FILE || scheme == ContentResolver.SCHEME_ANDROID_RESOURCE || scheme == ContentResolver.SCHEME_CONTENT || scheme == RawResourceDataSource.RAW_RESOURCE_SCHEME || scheme == "res" || host == null || host == "localhost" || host == "127.0.0.1" || host == "[::1]"
+    return scheme == null || scheme == ContentResolver.SCHEME_FILE || scheme == ContentResolver.SCHEME_ANDROID_RESOURCE || scheme == ContentResolver.SCHEME_CONTENT || scheme == RawResourceDataSource.RAW_RESOURCE_SCHEME || scheme == "res" || host == null"
 }

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/utils/Utils.kt
@@ -12,5 +12,5 @@ fun isUriLocalFile(uri: Uri?): Boolean {
     {
         return false
     }
-    return scheme == null || scheme == ContentResolver.SCHEME_FILE || scheme == ContentResolver.SCHEME_ANDROID_RESOURCE || scheme == ContentResolver.SCHEME_CONTENT || scheme == RawResourceDataSource.RAW_RESOURCE_SCHEME || scheme == "res" || host == null"
+    return scheme == null || scheme == ContentResolver.SCHEME_FILE || scheme == ContentResolver.SCHEME_ANDROID_RESOURCE || scheme == ContentResolver.SCHEME_CONTENT || scheme == RawResourceDataSource.RAW_RESOURCE_SCHEME || scheme == "res" || host == null
 }


### PR DESCRIPTION
Currently all local urls are retrieved by the `DefaultDataSourceFactory`. However, in my case I want to use localhost urls that return a redirect (302) to the actual mp3.
Therefore, since they are http/https urls, they should be handled by `DefaultHttpDataSource` so the redirect is followed.
This PR fixes the check `isLocalUri` to match local file uris only.

I have tested this with React Native Track Player.