### PR TITLE
Add http headers to notification artwork

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -38,6 +38,8 @@ import com.google.android.exoplayer2.ui.PlayerNotificationManager.CustomActionRe
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 
 class NotificationManager internal constructor(
     private val context: Context,
@@ -74,11 +76,13 @@ class NotificationManager internal constructor(
                 return bitmap
             }
             val artwork = getMediaItemArtworkUrl()
+            val headers = getNetworkHeaders()
             val holder = player.currentMediaItem?.getAudioItemHolder()
             if (artwork != null && holder?.artworkBitmap == null) {
                 context.imageLoader.enqueue(
                     ImageRequest.Builder(context)
                         .data(artwork)
+                        .headers(headers)
                         .target { result ->
                             val resultBitmap = (result as BitmapDrawable).bitmap
                             holder?.artworkBitmap = resultBitmap
@@ -110,6 +114,7 @@ class NotificationManager internal constructor(
     internal var overrideAudioItem: AudioItem? = null
         set(value) {
             notificationMetadataBitmap = null
+            val headers = getNetworkHeaders()
 
             if (field != value) {
                 if (value?.artwork != null) {
@@ -117,6 +122,7 @@ class NotificationManager internal constructor(
                     notificationMetadataArtworkDisposable = context.imageLoader.enqueue(
                         ImageRequest.Builder(context)
                             .data(value.artwork)
+                            .headers(headers)
                             .target { result ->
                                 notificationMetadataBitmap = (result as BitmapDrawable).bitmap
                                 invalidate()
@@ -170,6 +176,10 @@ class NotificationManager internal constructor(
         return overrideAudioItem?.artwork
             ?: mediaItem?.mediaMetadata?.artworkUri?.toString()
             ?: mediaItem?.getAudioItemHolder()?.audioItem?.artwork
+    }
+
+    private fun getNetworkHeaders(): Headers {
+        return player.currentMediaItem?.getAudioItemHolder()?.audioItem?.options?.headers?.toHeaders() ?: Headers.Builder().build()
     }
 
     /**


### PR DESCRIPTION
I'm using "Allowed Referrers" to protect my CDN from unwanted traffic. This PR adds the optional headers to the network request for the notification image so it's not blocked by the CDN.