### PR TITLE
feat: add audio usage type so it's possible to force audio from earpiece speaker

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioAttributesConfig.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioAttributesConfig.kt
@@ -1,0 +1,18 @@
+package com.doublesymmetry.kotlinaudio.models
+
+data class AudioAttributeConfig(
+
+    /**
+     * Whether audio focus should be managed automatically. See https://medium.com/google-exoplayer/easy-audio-focus-with-exoplayer-a2dcbbe4640e
+     */
+    val handleAudioFocus: Boolean = false,
+    /**
+     * The audio content type.
+     */
+    val audioContentType: AudioContentType = AudioContentType.MUSIC,
+
+    /**
+     * The audio usage type.
+     */
+    var audioUsageType: AudioUsageType = AudioUsageType.MEDIA
+)

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioUsageType.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/AudioUsageType.kt
@@ -1,0 +1,7 @@
+package com.doublesymmetry.kotlinaudio.models
+
+enum class AudioUsageType {
+    MEDIA,
+    VOICE_COMMUNICATION,
+}
+

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayerConfig.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/models/PlayerConfig.kt
@@ -25,6 +25,10 @@ data class PlayerConfig(
      */
     val handleAudioFocus: Boolean = false,
     /**
+     * The audio usage type.
+     */
+    val audioUsageType: AudioUsageType = AudioUsageType.MEDIA,
+    /**
      * The audio content type.
      */
     val audioContentType: AudioContentType = AudioContentType.MUSIC,


### PR DESCRIPTION
Makes it possible to set the audio usage attribute. By doing this it is possible to force the audio to come from the earpiece speaker. A useful use case is listening to voice messages.