### PR TITLE
fix: fix duplicate notification button on Android 13+

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -714,17 +714,23 @@ class NotificationManager internal constructor(
                     }
 
                     is NotificationButton.STOP -> {
-                        showStopButton = true
+                        if (!needsCustomActionsToAddMissingButtons) {
+                            showStopButton = true
+                        }
                     }
 
                     is NotificationButton.FORWARD -> {
-                        showForwardButton = true
-                        showForwardButtonCompact = button.isCompact
+                        if (!needsCustomActionsToAddMissingButtons) {
+                            showForwardButton = true
+                            showForwardButtonCompact = button.isCompact
+                        }
                     }
 
                     is NotificationButton.BACKWARD -> {
-                        showRewindButton = true
-                        showRewindButtonCompact = button.isCompact
+                        if (!needsCustomActionsToAddMissingButtons) {
+                            showRewindButton = true
+                            showRewindButtonCompact = button.isCompact
+                        }
                     }
 
                     is NotificationButton.NEXT -> {


### PR DESCRIPTION
I've noticed some custom systems like ColorOS 13+ (default system on OnePlus and Oppo devices) still support forward and rewind actions, however KotlinAudio will try to add additional custom actions if it's on Android 13+(as https://developer.android.com/about/versions/13/behavior-changes-13?hl=zh-cn#playback-controls suggests), which causes duplicate actions on such kind of devices.

This PR avoids add duplicate controls to exoplayer when we already added custom action buttons.

![20240531-144645](https://github.com/doublesymmetry/KotlinAudio/assets/1430376/fcc987d8-2169-4dad-87a8-65380c7e2bd0)

